### PR TITLE
Add --frail argument to remark to exit with 1 on warnings

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e # Exit immediately if a command exits with a non-zero status
 
 cd "${GITHUB_WORKSPACE}" || exit
 


### PR DESCRIPTION
Add `--frail` argument to remark to exit with `1` on warnings. Fixes #2.