### PR TITLE
:wrench: Updates dockerfile reviewdog install to nightly branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM prologic/remark-lint:latest
 
-RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin/ v0.11.0
+RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/nightly/master/install.sh| sh -s -- -b /usr/local/bin/
+# RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ v0.9.15
 RUN apk --no-cache -U add git
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
In order to use the new review dog `remark-lint` format, we temporary have to update to using the nightly branch.